### PR TITLE
fix: Add graph_repr_dim parameter to handle dimension mismatch in fusion

### DIFF
--- a/docs/quantum_descriptor_module.md
+++ b/docs/quantum_descriptor_module.md
@@ -148,6 +148,7 @@ module = QuantumDescriptorModule(
     num_descriptors=69,
     hidden_dim=256,
     output_dim=256,
+    graph_repr_dim=512,  # Dimension of graph representation (for fusion)
     num_decay_layers=4,
     use_gating=True,
 )

--- a/models/toxd4c.py
+++ b/models/toxd4c.py
@@ -105,6 +105,7 @@ class ToxD4C(nn.Module):
                 num_descriptors=config.get('num_quantum_descriptors', 69),
                 hidden_dim=config['hidden_dim'],
                 output_dim=config.get('quantum_descriptor_dim', 256),
+                graph_repr_dim=config['hidden_dim'],  # Match graph representation dimension
                 num_decay_layers=config.get('quantum_decay_layers', 4),
                 decay_rate=config.get('quantum_decay_rate', 0.1),
                 dropout=config['dropout'],


### PR DESCRIPTION
This fix addresses the review comment about dimension mismatch when graph_repr_main.shape[-1] (hidden_dim=512) differs from quantum_descriptor_dim (256).

Changes:
- Added graph_repr_dim parameter to QuantumDescriptorModule.__init__
- Added graph_proj layer to project graph representation to output_dim
- Updated fusion logic to use projected graph representation
- Updated ToxD4C to pass graph_repr_dim=hidden_dim to the module
- Updated documentation with new parameter

The fusion_gate now correctly expects [projected_graph(256) + descriptor(256)] = 512 instead of the previous incorrect [graph(512) + descriptor(256)] = 768.

## Summary by Sourcery

Handle dimension mismatch between graph representations and quantum descriptors in the fusion mechanism.

New Features:
- Add a configurable graph_repr_dim parameter to QuantumDescriptorModule to describe the incoming graph representation size.

Bug Fixes:
- Ensure fusion operates on matched dimensions by projecting graph representations to the quantum descriptor output_dim before gating.

Enhancements:
- Update ToxD4C configuration wiring to pass the model hidden_dim as graph representation dimension into QuantumDescriptorModule.
- Add a projection layer (or identity) for graph representations to align them with descriptor representations for fusion.

Documentation:
- Document the new graph_repr_dim parameter and its usage in QuantumDescriptorModule examples.